### PR TITLE
Make currency conversion on that month's historical rate.

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,9 +17,9 @@ export interface Context {
 
 // TODO: later try to use ReadSheets = 'read-sheets'
 export enum RunMode {
-    ReadSheets,
+    Import,
     ReadFile,
-    Import
+    ReadSheets
 }
 
 export enum Bank {
@@ -36,8 +36,8 @@ export enum User {
 
 export class Transaction {
     month: number;
-    year: string;
-    date: string; // format is DD/MM/YYYY
+    year: string; // TODO: Change this to number
+    date: string; // format is DD/MM/YYYY. TODO: Change this to actual date or moment.
     amount: number;
     amountEur: number;
     payee: string;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,16 +1,26 @@
 import * as getRates from 'ecb-fx-rates';
+import moment = require('moment');
 //import  { ExchangeRate, Currencies, ExchangeResponse } from 'exchange-rates-as-promised';
 
-let exchangeRateSEK: number;
+let currencyMap: Map<string, number> = new Map();
 
-
-async function convertSEKToEur(amount: number): Promise<number> {
-    if (this.exchangeRateSEK === undefined) {
+async function convertSEKToEur(amount: number, date: string): Promise<number> {
+    
+    const firstOfMonth: string = moment(date, 'D/M/YYYY').startOf('month').toString();
+    const found = currencyMap.get(firstOfMonth);
+    let exchangeRate;
+    if (!found) {
         // TODO: This library uses old xlm2json, which has dependencies to deprecated packages. Should change.
-        this.exchangeRateSEK = await getRates({currency: 'SEK'});
-        console.log('Rate fetched for SEK: ' + this.exchangeRateSEK);
+        console.log(`Fetching SEK rate for date: ${firstOfMonth.toString()}`);
+        exchangeRate = await getRates({currency: 'SEK', date: firstOfMonth});
+        if (exchangeRate) {
+            currencyMap.set(firstOfMonth, exchangeRate);
+        }
+        console.log(`Rate fetched for SEK: ${exchangeRate} for date: ${firstOfMonth.toString()}`);
+    } else {
+        exchangeRate = found;
     }
-    return Math.round((amount / this.exchangeRateSEK) * 100) / 100;
+    return Math.round((amount / exchangeRate) * 100) / 100;
 }
 
   /*

--- a/src/parsers/handelsbanken-parse.ts
+++ b/src/parsers/handelsbanken-parse.ts
@@ -24,7 +24,7 @@ async function readTransactionsFromFile(filePath: string): Promise<Transaction[]
     for (const line of xlsTransactionArray) {
         const transaction = parseLine(line);
         if (transaction) {
-            transaction.amountEur = await convertSEKToEur(transaction.amount);
+            transaction.amountEur = await convertSEKToEur(transaction.amount, transaction.date);
             transactions.push(transaction);
         }
     };

--- a/src/parsers/nordea-se-parse.ts
+++ b/src/parsers/nordea-se-parse.ts
@@ -21,7 +21,7 @@ async function readTransactionsFromFile(filePath: string): Promise<Transaction[]
     for (const line of xlsTransactionArray) {
         const transaction = parseLine(line);
         if (transaction) {
-            transaction.amountEur = await convertSEKToEur(transaction.amount);
+            transaction.amountEur = await convertSEKToEur(transaction.amount, transaction.date);
             transactions.push(transaction);
         }
     };
@@ -45,9 +45,9 @@ function parseLine(line: any): Transaction | null {
 
     let payment = {} as Transaction;
     const date = moment(line['Datum'], 'YYYY-MM-DD');
-    payment.month = date.month();
-    payment.year = `${date.year()}`;
-    payment.date = `${date.day()}/${date.month()}/${date.year()}`;
+    payment.month = parseInt(date.format('MM'));
+    payment.year = date.format('YYYY');
+    payment.date = date.format('DD/MM/YYYY');
     payment.payee = `${line['Transaktion']}`;
     payment.transactionType = '';
     payment.message = '';


### PR DESCRIPTION
This way it's possible to keep the old amounts equal between runs.

Fix bug with dates in NordeaSE, where I had used moment incorrectly.