### PR TITLE
Route all paths to index.html.

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,6 @@
 {
-  "buildCommand": "npm run test:run && npm run build"
+  "buildCommand": "npm run test:run && npm run build",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
 }


### PR DESCRIPTION
There was an issue where reloading eg /about on vercel would produce 404. This should fix it.