### PR TITLE
Fix ESLint errors and warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,7 +21,19 @@ export default tseslint.config(
       ...reactHooks.configs.recommended.rules,
       "react-refresh/only-export-components": [
         "warn",
-        { allowConstantExport: true },
+        {
+          allowConstantExport: true,
+          allowExportNames: [
+            "badgeVariants",
+            "buttonVariants",
+            "toggleVariants",
+            "navigationMenuTriggerStyle",
+            "useFormField",
+            "useSidebar",
+            "useAuth",
+            "useSettings",
+          ],
+        },
       ],
       "@typescript-eslint/no-unused-vars": "off",
     },

--- a/src/components/MultiBankFileUpload.tsx
+++ b/src/components/MultiBankFileUpload.tsx
@@ -114,7 +114,7 @@ export const MultiBankFileUpload = ({ onUploadSuccess, onUploadError }: MultiBan
       onUploadError(`Failed to parse ${bankInfo.name} file: ${error instanceof Error ? error.message : 'Unknown error'}`);
       setIsUploading(prev => ({ ...prev, [bankKey]: false }));
     }
-  }, [onUploadSuccess, onUploadError, selectedUser, settings.googleSheetsId]);
+  }, [onUploadSuccess, onUploadError]);
 
   // Handle categorization predictions update
   const handlePredictionsUpdate = (predictions: CategorizationPrediction[]) => {

--- a/src/lib/utils/text-preprocessing.ts
+++ b/src/lib/utils/text-preprocessing.ts
@@ -23,7 +23,7 @@ export function normalizeText(text: string): string {
     .toLowerCase()
     .trim()
     // Remove common special characters but keep spaces and basic punctuation
-    .replace(/[^\w\s\-\.]/g, ' ')
+    .replace(/[^\w\s\-.]/g, ' ')
     // Replace multiple spaces with single space
     .replace(/\s+/g, ' ')
     // Remove leading/trailing spaces
@@ -151,7 +151,7 @@ export function normalizeMultiLanguageText(text: string): string {
     // Remove numbers at the end (reference numbers)
     .replace(/\s+\d+$/, '')
     // Final cleanup
-    .replace(/[^\w\s\-\.]/g, ' ')
+    .replace(/[^\w\s\-.]/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves all current ESLint issues so `npm run lint` exits cleanly.

## Changes

- **`text-preprocessing.ts`**: Removed unnecessary `\.` escapes inside character classes (`/[^\w\s\-.]/g`).
- **`MultiBankFileUpload.tsx`**: Removed unused `selectedUser` and `settings.googleSheetsId` from the `onDrop` `useCallback` dependency array.
- **`eslint.config.js`**: Extended `react-refresh/only-export-components` with `allowExportNames` for standard shadcn/ui variant exports and context hooks (`useAuth`, `useSettings`, etc.).

## Verification

- `npm run lint` — passes with no errors or warnings
- `npm run test:run` — all 10 tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e87c117-6c87-451f-b661-d450c5e01556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e87c117-6c87-451f-b661-d450c5e01556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

