### PR TITLE
Remove hardcoded Firebase and Google API keys from source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Cursor Cloud specific instructions
 
-This is a client-side React 19 + Vite + TypeScript SPA (a bank-transaction file parser that imports into Google Sheets). There is no backend service in this repo — everything runs in the browser. Auth (Firebase) and Google Sheets config are hardcoded/dev values; no `.env` is required to run the app.
+This is a client-side React 19 + Vite + TypeScript SPA (a bank-transaction file parser that imports into Google Sheets). There is no backend service in this repo — everything runs in the browser. Firebase and Google Sheets credentials are loaded from environment variables. Copy `.env.sample` to `.env` before running the app or Cypress tests.
 
 ### Services / commands
 Standard scripts live in `package.json`. Key ones:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Vercel: https://expense-tracking-gsheet-importer.vercel.app/
 1. Make a copy of this sample sheet to your own account and use it as a base (header rows come from it): [https://docs.google.com/spreadsheets/d/1F78PxLNPdAFrcS8XjPI_hTAyh4knTVqq8kd-8ilmDSA/](https://docs.google.com/spreadsheets/d/1F78PxLNPdAFrcS8XjPI_hTAyh4knTVqq8kd-8ilmDSA/).
 1. Create and name the data sheets like this: If your name is `Aurelius` and your bank is `OP`, name the sheet `Aurelius OP`. You'll setup this in sheet-config next.
 1. Copy `sheet-config.json.sample` to `sheet-config.json`, and replace values with your own.
-1. Copy `.env.sample` to `.env`. You don't need to set any vars yet.
+1. Copy `.env.sample` to `.env` and fill in Firebase and Google Sheets API credentials (see Google Cloud setup below).
 
 1. Go here and complete the "prerequisites" section: [https://developers.google.com/sheets/api/quickstart/nodejs](https://developers.google.com/sheets/api/quickstart/nodejs).
     1. Create a project in Google Cloud Platform

--- a/cypress.config.mjs
+++ b/cypress.config.mjs
@@ -1,7 +1,10 @@
-
+import "dotenv/config";
 import { defineConfig } from "cypress";
 
 export default defineConfig({
+  env: {
+    VITE_FIREBASE_API_KEY: process.env.VITE_FIREBASE_API_KEY,
+  },
   e2e: {
     baseUrl: 'http://localhost:8080',
   },

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -141,7 +141,8 @@ Cypress.Commands.add('mockGoogleAuth', () => {
 // Improved Firebase auth mocking that sets the user in localStorage
 Cypress.Commands.add('mockFirebaseAuth', () => {
   // This approach properly mocks Firebase auth by setting localStorage state
-  localStorage.setItem('firebase:authUser:AIzaSyDBI1hjtEOufcGE4vuSh4gl1mOfUHTwm-Y:[DEFAULT]', 
+  const apiKey = Cypress.env('VITE_FIREBASE_API_KEY') ?? '';
+  localStorage.setItem(`firebase:authUser:${apiKey}:[DEFAULT]`, 
     JSON.stringify({
       uid: 'test-user-id',
       email: 'test@example.com',

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -2,16 +2,14 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth, GoogleAuthProvider } from 'firebase/auth';
 
-// Firebase configuration
-// Note: These are development values. In a production environment,
-// you should use environment variables for these values.
+// Firebase configuration (from .env)
 const firebaseConfig = {
-  apiKey: "AIzaSyDBI1hjtEOufcGE4vuSh4gl1mOfUHTwm-Y",
-  authDomain: "expense-tracker-328619.firebaseapp.com",
-  projectId: "expense-tracker-328619",
-  storageBucket: "expense-tracker-328619.appspot.com", // Corrected from .firebasestorage.app
-  messagingSenderId: "800525699041",
-  appId: "1:800525699041:web:7c156dce25e6192c3c34a0"
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID
 };
 
 // Initialize Firebase

--- a/src/lib/googleSheetsAPI.ts
+++ b/src/lib/googleSheetsAPI.ts
@@ -1,10 +1,9 @@
 
 import { toast } from "@/hooks/use-toast";
 
-// Google Sheets API configuration
-// You can set these values directly for development, but use environment variables for production
-const API_KEY = "AIzaSyDBI1hjtEOufcGE4vuSh4gl1mOfUHTwm-Y"; 
-const CLIENT_ID = "800525699041-13u158c8kfnopeh91ti1avpnj8gb03aj.apps.googleusercontent.com";
+// Google Sheets API configuration (from .env)
+const API_KEY = import.meta.env.VITE_GOOGLE_API_KEY ?? "";
+const CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID ?? "";
 const DISCOVERY_DOCS = ["https://sheets.googleapis.com/$discovery/rest?version=v4"];
 const SCOPES = "https://www.googleapis.com/auth/spreadsheets";
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,7 +4,15 @@
 declare const __BUILD_DATE__: string;
 
 interface ImportMetaEnv {
+  readonly VITE_FIREBASE_API_KEY: string;
+  readonly VITE_FIREBASE_AUTH_DOMAIN: string;
+  readonly VITE_FIREBASE_PROJECT_ID: string;
+  readonly VITE_FIREBASE_STORAGE_BUCKET: string;
+  readonly VITE_FIREBASE_MESSAGING_SENDER_ID: string;
+  readonly VITE_FIREBASE_APP_ID: string;
   readonly VITE_FIREBASE_FUNCTIONS_URL: string;
+  readonly VITE_GOOGLE_API_KEY: string;
+  readonly VITE_GOOGLE_CLIENT_ID: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves Firebase and Google Sheets API credentials out of source code and into environment variables (`VITE_*`), so secrets are no longer committed in `src/lib/firebase.ts` and `src/lib/googleSheetsAPI.ts`.

## Changes

- **`src/lib/firebase.ts`** — Firebase config now reads from `VITE_FIREBASE_*` env vars
- **`src/lib/googleSheetsAPI.ts`** — Google API key and OAuth client ID now read from `VITE_GOOGLE_*` env vars
- **`src/vite-env.d.ts`** — TypeScript declarations for the new env vars
- **`cypress.config.mjs`** / **`cypress/support/commands.ts`** — Cypress loads `VITE_FIREBASE_API_KEY` from `.env` for Firebase auth mocking
- **`.env.sample`** — Sample env file with the project's dev credentials (same values that were previously hardcoded)
- **`AGENTS.md`** / **`README.md`** — Document that `.env` is required for local dev and Cypress

## Setup

```bash
cp .env.sample .env
npm run dev
```

For Vercel/production, set the same `VITE_*` variables in the deployment environment.

## Testing

- `npm run check-types` — pass
- `npm run test:run` — 10/10 pass
- `npm run build` — pass
- `npm run dev` — app loads at http://localhost:8080
- `npm run cypress:run` — 3/4 pass (1 pre-existing failure in `google-auth.cy.ts` first test, also fails on `main`)

## Merge status

Merged latest `origin/main` (PR #85 dependabot security patches, PR #83 dev-environment docs). One conflict in `AGENTS.md` — resolved by combining main's PR media policy with env-based credentials documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e33d297a-4c6d-439a-bbe2-5dbee34d5473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e33d297a-4c6d-439a-bbe2-5dbee34d5473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

